### PR TITLE
Added link to Fedora Copr repository with RPM packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Under the hood this is a small systemd user service which implements the [search
 ### Packages & binaries
 
 - [AUR package](https://aur.archlinux.org/packages/gnome-search-providers-jetbrains/)
+- [Fedora RPM](https://copr.fedorainfracloud.org/coprs/dontfreakout/gnome-search-providers-jetbrains/)
 
 ### From source
 


### PR DESCRIPTION
I have added to README link to my repository with [RPM packages for Fedora](https://copr.fedorainfracloud.org/coprs/dontfreakout/gnome-search-providers-jetbrains/). 
